### PR TITLE
Ndp implementation TODOs

### DIFF
--- a/nanoPU_sim.py
+++ b/nanoPU_sim.py
@@ -28,16 +28,16 @@ cmd_parser.add_argument('--config', type=str, help='JSON config file to control 
 ####
 
 class Logger(object):
-    debug = True
-    def __init__(self):
+    def __init__(self, debug=True):
         self.env = Simulator.env
+        self.debug = debug
 
     @staticmethod
     def init_params():
         pass
 
     def log(self, s):
-        if Logger.debug:
+        if self.debug:
             print '{}: {}'.format(self.env.now, s)
 
 def DistGenerator(varname):
@@ -81,7 +81,7 @@ def DistGenerator(varname):
         elif dist == 'normal':
             yield int(np.random.normal(kwargs['mean'], kwargs['stddev']))
         elif dist == 'poisson':
-            yield np.random.poisson(kwargs['lambda']) 
+            yield np.random.poisson(kwargs['lambda'])
         elif dist == 'lognormal':
             yield int(np.random.lognormal(kwargs['mean'], kwargs['sigma']))
         elif dist == 'exponential':
@@ -116,7 +116,7 @@ class IngressPipe(object):
     """P4 programmable ingress pipeline"""
     def __init__(self, net_queue, assemble_queue):
         self.env = Simulator.env
-        self.logger = Logger() 
+        self.logger = Logger()
         self.net_queue = net_queue
         self.assemble_queue = assemble_queue
         self.env.process(self.start())
@@ -999,4 +999,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/nanoPU_sim.py
+++ b/nanoPU_sim.py
@@ -104,9 +104,12 @@ def find_first_one(bitmap):
     """
     if bitmap == 0:
         return None
-    assert bitmap > 0, "ERROR: bitmap must be positive"
-    bits = bin(bitmap)[2:][::-1]
-    return bits.find('1')
+    # assert bitmap > 0, "ERROR: bitmap must be positive"
+    # bits = bin(bitmap)[2:][::-1]
+    # return bits.find('1')
+
+    # Prevent twos complement sign issue.
+    return int(math.log(bitmap & -bitmap, 2))
 
 def priority_encoder(bitmap):
     """Select an index based on the deployed priority selection policies

--- a/nanoPU_sim.py
+++ b/nanoPU_sim.py
@@ -166,11 +166,17 @@ class IngressPipe(object):
                 dst_context = pkt[NDP].src_context
                 src_context = pkt[NDP].dst_context
 
-                pull_offset = 0
                 if pkt[NDP].flags.CHOP:
                     self.log('Processing chopped data pkt')
                     # send NACK
                     genNACK = True
+                    genPULL = True
+
+                    # TODO: this is not how NDP computes pull_offset, but just
+                    #       to get something running ...
+                    #       NDP would use the current pull offset state for this
+                    #       message!
+                    pull_offset = pkt[NDP].pkt_offset
                 else:
                     # process DATA pkt
                     genACK = True
@@ -594,7 +600,8 @@ class PktGen(object):
     def log(self, msg):
         self.logger.log('PktGen: {}'.format(msg))
 
-    def ctrlPktEvent(self, genACK, genNACK, genPULL, dst_ip, dst_context, src_context, tx_msg_id, msg_len, pkt_offset, pull_offset):
+    def ctrlPktEvent(self, genACK, genNACK, genPULL, dst_ip, dst_context,
+                     src_context, tx_msg_id, msg_len, pkt_offset, pull_offset):
         self.log('Processing ctrlPktEvent, genACK: {}, genNACK: {}, genPULL: {}'.format(genACK, genNACK, genPULL))
         # generate control pkt
         meta = EgressMeta(is_data=False, dst_ip=dst_ip)

--- a/nanoPU_sim.py
+++ b/nanoPU_sim.py
@@ -200,6 +200,11 @@ class IngressPipe(object):
                             pkt[NDP].payload)
                     self.assemble_queue.put(data)
                 # fire event to generate control pkt(s)
+                # TODO: Instead of providing some arguments to the packet
+                #       generator, we should provide the exact transport layer
+                #       header because we want the fixed function packet generator
+                #       to be able to generate packets for any transport protocol
+                #       that programmer deploys.
                 self.ctrlPktEvent(genACK, genNACK, genPULL, dst_ip,
                                   dst_context, src_context, tx_msg_id,
                                   msg_len, pkt_offset, pull_offset)


### PR DESCRIPTION
No code is changed in this pull request. 
This request is just to raise some TODO items that would allow us to discuss the design for implementability of NDP Transport protocol.

Can you also verify:
- State for tx messages are kept inside the reassembly module
- State for rx messages are kept inside the packetization module

If this is the case, we lose the programmability in our design in terms of transport protocol deployments in L-NIC. I strongly support the idea of keeping state within the p4 pipelines (with some large SRAM) so that both the behavior and the state required for that behavior can be described by the programmer.